### PR TITLE
表記誤りの修正

### DIFF
--- a/whatsnew/20231222_takibar/index.html
+++ b/whatsnew/20231222_takibar/index.html
@@ -55,7 +55,7 @@
                 </p>
                 <div class="border b_4"></div>
                 <p class="p_left">
-                    *You need to show your TUFS student ID to enter.
+                    *You need to show your Tokyo Tech student ID to enter.
                     <br><span class="bd">※入場には本学学生証の提示が必要です。</span>
 
                     <br><br>*Admission fee of 300 yen will be collected.


### PR DESCRIPTION
学生証の英語表記をTokyo Techに修正