### PR TITLE
3/8公開分のblogを完成

### DIFF
--- a/blog/20240308_shinkan1/index.html
+++ b/blog/20240308_shinkan1/index.html
@@ -4,7 +4,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta charset="UTF-8" />
     <link rel="stylesheet" href="../blog.css" />
-    <link rel="stylesheet" href="sections.css" />
     <link rel="stylesheet" href="../blog_resp.css" />
     <link rel="stylesheet" href="../../_commons/common.css" />
     <link rel="stylesheet" href="../../_commons/common_resp.css" />
@@ -38,7 +37,7 @@
           <h3>TPGってどんな団体？【2024年度新歓ブログリレーvol.1】</h3>
         </div>
       </div>
-      <div class="picture">
+      <div class="images">
         <img src="./_img/1_logo.webp" alt="" />
       </div>
       <p>
@@ -57,13 +56,15 @@
         <a href="#section2" alt="">普段は何をしているの？</a><br />
         <a href="#section3" alt="">TPGが気になったあなたへ！！</a><br />
       </p>
-      <h5 id="section1" class="sections">TPGってどういう団体？</h5>
+      <h5 id="section1" class="contents">TPGってどういう団体？</h5>
       <p>
         一言でいうと、「Taki Plazaで自由に企画運営する学生団体」です。
         そもそもTaki
         Plazaとは？というと、東工大の大岡山キャンパスにある国際・学生交流、学生支援を目的として建てられた施設です。
         こう書くとなんだか堅苦しく見えますが、自由に集まって自習をしたりゲームをしたりと皆思い思いにくつろいでいます。カフェが併設されていたり、予約して使えるキッチンもあったり。個人的には電子レンジがあるのでとても助かってます。
-        Taki Plazaについて詳しく知りたい人は<a href="https://tpgd.jp" alt=""
+        Taki Plazaについて詳しく知りたい人は<a
+          href="https://takiplaza.gakumu.titech.ac.jp/"
+          alt=""
           >Taki Plazaの公式HP</a
         >や<a href="https://tpgd.jp/blog/20220228_takiplaza/index.html" alt=""
           >過去のブログリレー</a
@@ -72,7 +73,12 @@
       <div class="picture">
         <img src="./_img/2_taki.webp" alt="" />
       </div>
-      <h5 id="section2" class="sections">普段は何をしているの？</h5>
+      <p>
+        TPGは、そんなTaki
+        Plazaでイベントやワークショップを企画・運営したり、時期に合わせた装飾によって空間づくりをしたり…と、Taki
+        Plazaがより居心地よく感じられる施設になること、交流や新たなつながりが生まれるきっかけとなることを目指して活動しています。
+      </p>
+      <h5 id="section2" class="contents">普段は何をしているの？</h5>
       <p>
         TPGはイベント班、コミュニティ班、広報班、制作班、マネジメント班の5つの班に分かれて活動しています。
         イベント班であれば次に行うイベントの案出しや企画、準備をしたり、制作班であればイベントのポスターをつくったり装飾を考えたり、といった具合です。
@@ -88,15 +94,13 @@
         ミーティングの時間でなくとも、なんとなく居室に来て一緒にお昼を食べたり、勉強をしたりとメンバーがそれぞれ自由に過ごしています。
         また、2泊3日夏合宿や学年懇親会など、班の違うメンバーと仲良くなる機会もたくさんあります。
       </p>
-      <div class="picture">
+      <div class="images">
         <img src="./_img/3_pic.webp" alt="" />
       </div>
       <p>
-        TPGは、そんなTaki
-        Plazaでイベントやワークショップを企画・運営したり、時期に合わせた装飾によって空間づくりをしたり…と、Taki
-        Plazaがより居心地よく感じられる施設になること、交流や新たなつながりが生まれるきっかけとなることを目指して活動しています。
+        現在のメンバー構成は学士３年(22B)が31名、学士2年(23B)が15名の計56名が所属しています。TPGは学士3年の10月で引退するので、1~3年生がそろっている時期は毎年70名程の団体となります。
       </p>
-      <h5 id="section3" class="sections">TPGが気になったあなたへ！！</h5>
+      <h5 id="section3" class="contents">TPGが気になったあなたへ！！</h5>
       <p>
         今所属しているメンバーは、なんとなくTPGに惹かれて入った人がたくさんいます。(私もなぜ自分がTPGに入ったかはわかりませんが今となっては自分にとってTPGのない学生生活は想像できません…笑)
         活動が楽しい、という以前にメンバー同士不思議とTPGという団体が好きなのかなとぼんやり感じています。そしてここまで読んでくださった皆さんにもTPGに興味を持っていただけていたら嬉しいです。

--- a/blog/20240308_shinkan1/sections.css
+++ b/blog/20240308_shinkan1/sections.css
@@ -1,4 +1,0 @@
-.sections {
-  padding-top: 110px;
-  margin-top: -110px;
-}

--- a/blog/blog.css
+++ b/blog/blog.css
@@ -32,6 +32,8 @@ h5 {
 }
 .contents {
   margin-bottom: 20px;
+  margin-top: -110px;
+  padding-top: 110px;
 }
 .contents a {
   display: block;

--- a/blog/index.html
+++ b/blog/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="ja">
   <head>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta charset="UTF-8" />
@@ -35,7 +35,22 @@
         <a href="#" id="blog23">2023ブログリレー</a>
         <a href="#" id="blog22">2022ブログリレー</a>
       </div>
+
       <div class="articles">
+        <div class="article b24">
+          <div class="text">
+            <p id="cc">2024年3月8日</p>
+            <h3 id="cc">
+              TPGってどんな団体？【2024年度新歓ブログリレーvol.1】
+            </h3>
+            <p id="cc">
+              こんにちは、Taki Plaza Gardener(通称TPG)のリーダーの小泉です。
+              東工大に合格された皆さん、本当におめでとうございます！…
+            </p>
+          </div>
+          <img src="./20240308_shinkan1/_img/1_logo.webp" alt="" />
+          <a href="./20240308_shinkan1/index.html" alt=""></a>
+        </div>
         <div class="article b23">
           <div class="text">
             <p id="cc">2023年5月12日</p>
@@ -47,8 +62,8 @@
               新入生の皆さん、大学は慣れてきましたか？もう１Ｑも半分を過ぎましたね。本当に時の流れは早いなってつくづく思います…
             </p>
           </div>
-          <img src="./20230512_bunkei/_img/bunkei_midashi.webp" />
-          <a href="./20230512_bunkei/index.html"></a>
+          <img src="./20230512_bunkei/_img/bunkei_midashi.webp" alt="" />
+          <a href="./20230512_bunkei/index.html" alt=""></a>
         </div>
         <div class="article b23">
           <div class="text">
@@ -59,8 +74,8 @@
             </h3>
             <p id="cc">学生証を受け取ったらすぐに使おう！学割特集！！…</p>
           </div>
-          <img src="./20230402_otoku/_img/goukaku.webp" />
-          <a href="./20230402_otoku/index.html"></a>
+          <img src="./20230402_otoku/_img/goukaku.webp" alt="" />
+          <a href="./20230402_otoku/index.html" alt=""></a>
         </div>
         <div class="article b23">
           <div class="text">
@@ -74,8 +89,8 @@
               この時期、新入生の皆さんは春からの大学生活にドキドキするとともに、新たな生活に不安をフアンと感じているのではな…
             </p>
           </div>
-          <img src="./20230328_kamoku/_img/sozai.webp" />
-          <a href="./20230328_kamoku/index.html"></a>
+          <img src="./20230328_kamoku/_img/sozai.webp" alt="" />
+          <a href="./20230328_kamoku/index.html" alt=""></a>
         </div>
         <div class="article b23">
           <div class="text">
@@ -85,8 +100,8 @@
               TPGの新歓ブログリレーをここまで読んでくれたみなさん、ありがとうございます。まだの人はぜひ他班やリーダー、副リーダーの紹介も覗いてみてください。TPGの…
             </p>
           </div>
-          <img src="./20230324_production/_img/takifes.webp" />
-          <a href="./20230324_production/index.html"></a>
+          <img src="./20230324_production/_img/takifes.webp" alt="" />
+          <a href="./20230324_production/index.html" alt=""></a>
         </div>
         <div class="article b23">
           <div class="text">
@@ -98,8 +113,8 @@
               その疑問を今回の説明で解決したいと思います…
             </p>
           </div>
-          <img src="./20230320_community/_img/community.webp" />
-          <a href="./20230320_community/index.html"></a>
+          <img src="./20230320_community/_img/community.webp" alt="" />
+          <a href="./20230320_community/index.html" alt=""></a>
         </div>
         <div class="article b23">
           <div class="text">
@@ -109,8 +124,8 @@
               マネジメント班は「TPGの裏方役」として活動を行っています。他の班が主に外部に向けての活動を行っている中、組織内部をより良くするために活動を行っており…
             </p>
           </div>
-          <img src="./20230318_management/_img/management.webp" />
-          <a href="./20230318_management/index.html"></a>
+          <img src="./20230318_management/_img/management.webp" alt="" />
+          <a href="./20230318_management/index.html" alt=""></a>
         </div>
         <div class="article b23">
           <div class="text">
@@ -121,8 +136,8 @@
               Plazaはぐるなびの会長である滝久…
             </p>
           </div>
-          <img src="./20230314_pr/_img/blog_pr.webp" />
-          <a href="./20230314_pr/index.html"></a>
+          <img src="./20230314_pr/_img/blog_pr.webp" alt="" />
+          <a href="./20230314_pr/index.html" alt=""></a>
         </div>
         <div class="article b23">
           <div class="text">
@@ -133,8 +148,8 @@
               新入生のみなさんは大学生活への期待に胸を膨らませているでしょうか？サークルや履修登録に対する不安も大きい頃でし…
             </p>
           </div>
-          <img src="./20230311_event/_img/wakabasai_logo.webp" />
-          <a href="./20230311_event/index.html"></a>
+          <img src="./20230311_event/_img/wakabasai_logo.webp" alt="" />
+          <a href="./20230311_event/index.html" alt=""></a>
         </div>
         <div class="article b23">
           <div class="text">
@@ -146,8 +161,8 @@
               リーダーはTPGの顔としての外向きの立場な…
             </p>
           </div>
-          <img src="./20230306_leadersub/_img/dahyon.webp" />
-          <a href="./20230306_leadersub/index.html"></a>
+          <img src="./20230306_leadersub/_img/dahyon.webp" alt="" />
+          <a href="./20230306_leadersub/index.html" alt=""></a>
         </div>
         <div class="article b23">
           <div class="text">
@@ -159,8 +174,8 @@
               目次 自己紹介 リーダーの役割って？…
             </p>
           </div>
-          <img src="./20230301_leader/_img/blog_leader.webp" />
-          <a href="./20230301_leader/index.html"></a>
+          <img src="./20230301_leader/_img/blog_leader.webp" alt="" />
+          <a href="./20230301_leader/index.html" alt=""></a>
         </div>
         <div class="article b23">
           <div class="text">
@@ -172,8 +187,8 @@
               楽しい大学生活が送れること…
             </p>
           </div>
-          <img src="./20230225_abouttpg/_img/tpg_logos.webp" />
-          <a href="./20230225_abouttpg/index.html"></a>
+          <img src="./20230225_abouttpg/_img/tpg_logos.webp" alt="" />
+          <a href="./20230225_abouttpg/index.html" alt=""></a>
         </div>
         <div class="article b22">
           <div class="text">
@@ -183,8 +198,8 @@
               こんにちは、広報班班長の早瀬です。新歓が落ち着いてきたサークル・部活動も多いとは思うのですが、TPGではまだまだ新規入会を大募集しております。ということ…
             </p>
           </div>
-          <img src="./20220508_pr/_img/ookayamamap.webp" />
-          <a href="./20220508_pr/index.html"></a>
+          <img src="./20220508_pr/_img/ookayamamap.webp" alt="" />
+          <a href="./20220508_pr/index.html" alt=""></a>
         </div>
         <div class="article b22">
           <div class="text">
@@ -198,8 +213,8 @@
               今回のテーマは「Taki Plazaのコンセント事情」で…
             </p>
           </div>
-          <img src="./20220422_plug/_img/floor1.webp" />
-          <a href="./20220422_plug/index.html"></a>
+          <img src="./20220422_plug/_img/floor1.webp" alt="" />
+          <a href="./20220422_plug/index.html" alt=""></a>
         </div>
         <div class="article b22">
           <div class="text">
@@ -209,8 +224,8 @@
               こんにちは！広報班班長の早瀬です。すでに過去の新歓ブログをチェックしてくださっている方は何度か僕の名前を見かけたことかと思います。何度もすみません。…
             </p>
           </div>
-          <img src="./20220422_shoukai2/_img/shoukai2.webp" />
-          <a href="./20220422_shoukai2/index.html"></a>
+          <img src="./20220422_shoukai2/_img/shoukai2.webp" alt="" />
+          <a href="./20220422_shoukai2/index.html" alt=""></a>
         </div>
         <div class="article b22">
           <div class="text">
@@ -222,8 +237,8 @@
               初めまして！マネジメント班長の野口です…
             </p>
           </div>
-          <img src="./20220418_interview/_img/publicart.webp" />
-          <a href="./20220418_interview/index.html"></a>
+          <img src="./20220418_interview/_img/publicart.webp" alt="" />
+          <a href="./20220418_interview/index.html" alt=""></a>
         </div>
         <div class="article b22">
           <div class="text">
@@ -237,8 +252,8 @@
               ぜひ最後まで読…
             </p>
           </div>
-          <img src="./20220415_cafe/_img/gaikan.webp" />
-          <a href="./20220415_cafe/index.html"></a>
+          <img src="./20220415_cafe/_img/gaikan.webp" alt="" />
+          <a href="./20220415_cafe/index.html" alt=""></a>
         </div>
         <div class="article b22">
           <div class="text">
@@ -248,8 +263,8 @@
               皆さんこんにちは！TPG広報班の早瀬です。ブログの更新がややおろそかになってしまい申し訳ありません、、、いよいよ授業がスタートしましたね！皆さんの大学生活が本格的にスタートしたということで、充実…
             </p>
           </div>
-          <img src="./20220411_shoukai1/_img/shoukai1.webp" />
-          <a href="./20220411_shoukai1/index.html"></a>
+          <img src="./20220411_shoukai1/_img/shoukai1.webp" alt="" />
+          <a href="./20220411_shoukai1/index.html" alt=""></a>
         </div>
         <div class="article b22">
           <div class="text">
@@ -261,8 +276,8 @@
               最初に結論を言うと、若葉祭は新歓や学生の交流…
             </p>
           </div>
-          <img src="./20220403_wakabasai/_img/wakabasai.webp" />
-          <a href="./20220403_wakabasai/index.html"></a>
+          <img src="./20220403_wakabasai/_img/wakabasai.webp" alt="" />
+          <a href="./20220403_wakabasai/index.html" alt=""></a>
         </div>
         <div class="article b22">
           <div class="text">
@@ -275,8 +290,8 @@
               少な…
             </p>
           </div>
-          <img src="./20220330_wellness/_img/wellness.webp" />
-          <a href="./20220330_wellness/index.html"></a>
+          <img src="./20220330_wellness/_img/wellness.webp" alt="" />
+          <a href="./20220330_wellness/index.html" alt=""></a>
         </div>
         <div class="article b22">
           <div class="text">
@@ -287,8 +302,8 @@
               TPG広報班の桑原です。新入生の皆さん、合格発表後はどうお過ごしでしょうか。長時間勉強に充ててたのが一気に解放されるわけですから、この時期は暇ですよね。私の場合はこたつに入ってスマホずっと…
             </p>
           </div>
-          <img src="./20220327_zemi/_img/zemi.webp" />
-          <a href="./20220327_zemi/index.html"></a>
+          <img src="./20220327_zemi/_img/zemi.webp" alt="" />
+          <a href="./20220327_zemi/index.html" alt=""></a>
         </div>
         <div class="article b22">
           <div class="text">
@@ -298,8 +313,8 @@
               こんにちは、広報班班長の早瀬です。改めて、新入生の皆さんはご入学おめでとうございます🌸🌸このブログが公開される頃には、皆さんの入学や履修の準備も少しず…
             </p>
           </div>
-          <img src="./20220324_jugyou/_img/osusume_banner.webp" />
-          <a href="./20220324_jugyou/index.html"></a>
+          <img src="./20220324_jugyou/_img/osusume_banner.webp" alt="" />
+          <a href="./20220324_jugyou/index.html" alt=""></a>
         </div>
         <div class="article b22">
           <div class="text">
@@ -310,8 +325,8 @@
               Gardener(以下TPG)というサークルで副リーダーをやっているアシカワという者です。「TPGってな…
             </p>
           </div>
-          <img src="./20220320_jikanwari/_img/jikanwari_banner.webp" />
-          <a href="./20220320_jikanwari/index.html"></a>
+          <img src="./20220320_jikanwari/_img/jikanwari_banner.webp" alt="" />
+          <a href="./20220320_jikanwari/index.html" alt=""></a>
         </div>
         <div class="article b22">
           <div class="text">
@@ -324,8 +339,8 @@
               辛く長い受験勉強生活を耐え抜き、波乱の共通テストを乗り越えて、入試の複素数平面を完全…
             </p>
           </div>
-          <img src="./20220315_shinkan/_img/shinkan_banner.webp" />
-          <a href="./20220315_shinkan/index.html"></a>
+          <img src="./20220315_shinkan/_img/shinkan_banner.webp" alt="" />
+          <a href="./20220315_shinkan/index.html" alt=""></a>
         </div>
         <div class="article b22">
           <div class="text">
@@ -340,8 +355,8 @@
               この時期…
             </p>
           </div>
-          <img src="./20220313_goukaku/_img/goukaku_banner.webp" />
-          <a href="./20220313_goukaku/index.html"></a>
+          <img src="./20220313_goukaku/_img/goukaku_banner.webp" alt="" />
+          <a href="./20220313_goukaku/index.html" alt=""></a>
         </div>
         <div class="article b22">
           <div class="text">
@@ -352,8 +367,8 @@
               最近iPhone8から13に機種変をしたんですが、あまりに画質が良いのが楽しくて…
             </p>
           </div>
-          <img src="./20220303_tpg/_img/tpg_banner.webp" />
-          <a href="./20220303_tpg/index.html"></a>
+          <img src="./20220303_tpg/_img/tpg_banner.webp" alt="" />
+          <a href="./20220303_tpg/index.html" alt=""></a>
         </div>
         <div class="article b22">
           <div class="text">
@@ -364,8 +379,11 @@
               私は春から学士3年ですが、いやぁもう時が経つのは早いなとつくづく思いますね…。みなさんぜひやりたいこと全部やって楽しい大学生活を…
             </p>
           </div>
-          <img src="./20220228_takiplaza/_img/kaitaishinsyo_banner.webp" />
-          <a href="./20220228_takiplaza/index.html"></a>
+          <img
+            src="./20220228_takiplaza/_img/kaitaishinsyo_banner.webp"
+            alt=""
+          />
+          <a href="./20220228_takiplaza/index.html" alt=""></a>
         </div>
         <div class="article b22">
           <div class="text">
@@ -376,8 +394,8 @@
               本記事を書いた、広報班の桑原です。学生の皆さんは春休みをどうお過ごしでしょうか？私は徹夜をするなどして生活習慣が崩壊しています。今日も深夜5時…
             </p>
           </div>
-          <img src="./20220225_pc/_img/pc_banner.webp" />
-          <a href="./20220225_pc/index.html"></a>
+          <img src="./20220225_pc/_img/pc_banner.webp" alt="" />
+          <a href="./20220225_pc/index.html" alt=""></a>
         </div>
       </div>
     </div>


### PR DESCRIPTION
指摘されてた修正点のほかに、僕の確認ミスで、前回はアンカーリンク化する際にsectionsというclassをつけて、3/8の分のフォルダにそれ専用のcssを作って読み込んで適用させていましたが、blog統一のcssを使うようにしました。そのため
- 読込先の変更
- sections.cssの削除
- blog.cssの変更

が入ってます。
その際に、blog統一のcssではヘッダーの分の余白が考慮されておらず、アンカーリンクを押したときに文字がヘッダーとかぶってしまっていたので、**paddingをある程度の値与えたうえで、負の値のmarginを指定して打ち消しつつアンカーリンクではきれいに見えるようにblog.cssも修正**してあります。
あとimgタグとaタグはaltを指定しないと怒られるので書き足してあります。