### PR TITLE
fix: スケジュールの年度を2025年度から2026年度に更新

### DIFF
--- a/src/pages/signage-application.astro
+++ b/src/pages/signage-application.astro
@@ -34,7 +34,7 @@ const description = "Taki Plaza B2Fの大きなモニター(9面マルチモニ�
     </Heading>
     <Heading title="スケジュール">
         <table class="schedule-table" border="1" cellspacing="0" cellpadding="6">
-        <caption>2025年度スケジュール</caption>
+        <caption>2026年度スケジュール</caption>
         <thead>
             <tr>
             <th>期</th>


### PR DESCRIPTION
- signage-application.astroのスケジュールセクションで、キャプションの年度を2026年度に変更しました。