### PR TITLE
fix: 若葉祭2026のタイトルと説明を修正

### DIFF
--- a/src/content/news-en/260520.mdx
+++ b/src/content/news-en/260520.mdx
@@ -1,6 +1,6 @@
 ---
 title: "We held Wakaba Festival"
-description:“The Taki Plaza Gardener Event Team held the Wakaba Festival 2026 on Friday, April 10, and Saturday, April 11, 2026!”
+description: "The Taki Plaza Gardener Event Team held the Wakaba Festival 2026 on Friday, April 10, and Saturday, April 11, 2026!"
 date: 2026-05-20
 tags: ["Event Report"]
 ---
@@ -15,9 +15,8 @@ import circle_2 from "@assets/news/260520/circle_2.jpg";
 import workshop_1 from "@assets/news/260520/workshop_1.jpg";
 import workshop_2 from "@assets/news/260520/workshop_2.jpg";
 
-
 We held Wakaba Festival 2026 on Friday, April 10, and Saturday, April 11, 2026!
-  
+
 Now in its fifth year, this event is the largest joint club welcome event on campus.
 This year’s theme was “Chapter 1,” and the event was held to support new students as they take their first steps into university life.
 Over the two days, more than 500 new students participated, making it a lively gathering for socializing.
@@ -30,41 +29,19 @@ Translated with DeepL.com (free version)
 This year, a total of 37 clubs—including sports and cultural groups—participated.  
 Through their booths and activities, attendees had the opportunity to experience firsthand what each club is all about and get a feel for their atmosphere.
 
-<ArticleImage
-  src={circle_1}
-  alt="circle booths 1"
-  caption="circle booth"
-/>
-<ArticleImage
-  src={circle booth 2}
-  alt="circle booth 2"
-/>
+<ArticleImage src={circle_1} alt="circle booths 1" caption="circle booth" />
+<ArticleImage src={circle_2} alt="circle booth 2" />
 
 We could see that the new students were actively engaging with others, listening to presentations about clubs that piqued their interest and even trying them out for themselves.
 Conversations were flowing all over the venue, and the atmosphere was lively the entire time.
 
-<ArticleImage
-  src={workshop_1}
-  alt="workshop room 1"
-  caption="workshop room"
-/>
-<ArticleImage
-  src={workshop_2}
-  alt="workshop room 2"
-/>
+<ArticleImage src={workshop_1} alt="workshop room 1" caption="workshop room" />
+<ArticleImage src={workshop_2} alt="workshop room 2" />
 
 Each group put on creative events, and the performances on the outdoor stairs of Taki Plaza and in the 70th Anniversary Auditorium were particularly lively, drawing large crowds.
 
-<ArticleImage
-  src={outdoor_stair}
-  alt="outdoor stair"
-  caption="outdoor stair"
-/>
-<ArticleImage
-  src={auditorium}
-  alt="auditorium"
-  caption="auditorium"
-/>
+<ArticleImage src={outdoor_stair} alt="outdoor stair" caption="outdoor stair" />
+<ArticleImage src={auditorium} alt="auditorium" caption="auditorium" />
 
 After the event, we received lots of wonderful feedback.  
 “It was so much fun to try out so many different activities!”  

--- a/src/content/news-ja/260520.mdx
+++ b/src/content/news-ja/260520.mdx
@@ -1,5 +1,5 @@
 ---
-title: "TPGイベント班が「新入生交流会」を開催しました！"
+title: "TPGイベント班が「若葉祭2026」を開催しました！"
 description: "Taki Plaza Gardener イベント班が2026年4月10日(金)、11日(土)に若葉祭2026を開催しました！"
 date: 2026-05-20
 tags: ["開催報告"]
@@ -15,12 +15,12 @@ import circle_2 from "@assets/news/260520/circle_2.jpg";
 import workshop_1 from "@assets/news/260520/workshop_1.jpg";
 import workshop_2 from "@assets/news/260520/workshop_2.jpg";
 
-
 Taki Plaza Gardener イベント班が2026年4月10日(金)、11日(土)に若葉祭2026を開催しました！
-  
+
 本イベントは今年で5年目を迎えた、学内最大規模のサークル合同新歓イベントです。
 今年度は「Chapter 1」をテーマに掲げ、新たな大学生活の第一歩を後押しする場として開催しました。
 当日は2日間で500名以上の新入生の方にご参加いただき、にぎやかな交流の場となりました。
+
 <ArticleImage src={img_1} alt="盛況の様子1" />
 <ArticleImage src={img_2} alt="盛況の様子2" />
 
@@ -32,10 +32,7 @@ Taki Plaza Gardener イベント班が2026年4月10日(金)、11日(土)に若�
   alt="サークルブースの様子1"
   caption="サークルブースの様子"
 />
-<ArticleImage
-  src={circle_2}
-  alt="サークルブースの様子2"
-/>
+<ArticleImage src={circle_2} alt="サークルブースの様子2" />
 
 新入生の皆さんも、気になる団体の話を聞いたり実際に体験したりと、積極的に交流されている様子が見られました。
 会場のあちこちで会話が弾み、終始活気にあふれていました。
@@ -45,23 +42,12 @@ Taki Plaza Gardener イベント班が2026年4月10日(金)、11日(土)に若�
   alt="ワークショップルームの様子1"
   caption="ワークショップルームの様子"
 />
-<ArticleImage
-  src={workshop_2}
-  alt="サークルブースの様子1"
-/>
+<ArticleImage src={workshop_2} alt="サークルブースの様子1" />
 
 各団体が工夫を凝らした企画を実施し、特にTaki Plaza外階段や70周年記念講堂でのパフォーマンスは大きな盛り上がりを見せ、多くの人で賑わっていました。
 
-<ArticleImage
-  src={outdoor_stair}
-  alt="外階段の様子"
-  caption="外階段の様子"
-/>
-<ArticleImage
-  src={auditorium}
-  alt="講堂の様子"
-  caption="講堂の様子"
-/>
+<ArticleImage src={outdoor_stair} alt="外階段の様子" caption="外階段の様子" />
+<ArticleImage src={auditorium} alt="講堂の様子" caption="講堂の様子" />
 
 イベント後には、嬉しい感想をたくさんいただきました。  
 「いろんな体験ができて楽しかったです！」  


### PR DESCRIPTION
- タイトルを「新入生交流会」から「若葉祭2026」に変更
- 説明文のフォーマットを修正
- 不要な改行を削除し、コードの可読性を向上